### PR TITLE
起算日リスト画面の追加

### DIFF
--- a/app/Http/Controllers/JobOfferController.php
+++ b/app/Http/Controllers/JobOfferController.php
@@ -179,8 +179,9 @@ class JobOfferController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function edit($id)
+    public function edit(Request $request, $id)
     {
+        $fromOrderDate = $request->query('from_order_date') ?? '';
         $jobOffer = JobOffer::find($id);
         $jobOffer['holiday'] = json_decode($jobOffer['holiday']);
         if ($jobOffer['long_vacation']) {
@@ -205,6 +206,7 @@ class JobOfferController extends Controller
             'activityRecords' => $activityRecords,
             'isDraftJobOffer' => false,
             'differentUserAlert' => $differentUserAlert,
+            'fromOrderDate' => $fromOrderDate,
         ]);
     }
 
@@ -404,8 +406,7 @@ class JobOfferController extends Controller
                     ]
                 );
             }
-
-            return redirect(route('job_offers.index'));
+            return redirect(empty($request->fromOrderDate) ? route('job_offers.index') : route('jobffer.order_date.index'));
         }
 
     }
@@ -442,32 +443,6 @@ class JobOfferController extends Controller
         ->when($request->postingSite, function ($query, $postingSite) {
             return $query->whereIn('posting_site', $postingSite);
         })
-        // ->when($request->keywords, function ($query, $keywords) {
-        //     $smallSpaceKeywords = mb_convert_kana($keywords, 's');
-        //     $keywords = explode(' ', $smallSpaceKeywords);
-
-        //     // キーワードはAND、カラムはOR
-        //     foreach($keywords as $keyword) {
-        //         if (array_search($keyword, config('options.holiday'))) {
-        //             $keyword = array_search($keyword, config('options.holiday'));
-        //         }
-        //         if (array_search($keyword, config('options.long_vacation'))) {
-        //             $keyword = array_search($keyword, config('options.long_vacation'));
-        //         }
-        //         $query->where(function($query) use ($keyword){
-        //             $query->where('company_name', 'LIKE', "%{$keyword}%")
-        //                 ->orWhere('company_address', 'LIKE', "%{$keyword}%")
-        //                 ->orWhere('ordering_business', 'LIKE', "%{$keyword}%")
-        //                 ->orWhere('order_details', 'LIKE', "%{$keyword}%")
-        //                 ->orWhere('scheduled_period', 'LIKE', "%{$keyword}%")
-        //                 ->orWhere('holiday', 'LIKE', "%{$keyword}%")
-        //                 ->orWhere('long_vacation', 'LIKE', "%{$keyword}%")
-        //                 ->orWhere('scheduled_period', 'LIKE', "%{$keyword}%");
-        //         });
-        //     }
-
-        //     return $query;
-        // })
         ->orderBy('created_at', 'desc')
         ->get();
 

--- a/app/Http/Controllers/JobOfferController.php
+++ b/app/Http/Controllers/JobOfferController.php
@@ -420,4 +420,62 @@ class JobOfferController extends Controller
         return redirect(route('job_offers.index'));
     }
 
+    public function showOrderDate(Request $request)
+    {
+        $draftJobOffers = DraftJobOffer::all();
+        $users = User::all();
+        $jobOffers = JobOffer::when($request->userId, function ($query, $userId) {
+            return $query->where('user_id', $userId);
+        })
+        ->when($request->companyName, function ($query, $companyName) {
+            return $query->where('company_name', 'like' , "%{$companyName}%");
+        })
+        ->when($request->jobNumber, function ($query, $jobNumber) {
+            return $query->where('job_number', $jobNumber);
+        })
+        ->when($request->orderingBusiness, function ($query, $orderingBusiness) {
+            return $query->where('ordering_business', $orderingBusiness);
+        })
+        ->when($request->orderDate, function ($query, $orderDate) {
+            return $query->whereDate('order_date', $orderDate);
+        })
+        ->when($request->postingSite, function ($query, $postingSite) {
+            return $query->whereIn('posting_site', $postingSite);
+        })
+        // ->when($request->keywords, function ($query, $keywords) {
+        //     $smallSpaceKeywords = mb_convert_kana($keywords, 's');
+        //     $keywords = explode(' ', $smallSpaceKeywords);
+
+        //     // キーワードはAND、カラムはOR
+        //     foreach($keywords as $keyword) {
+        //         if (array_search($keyword, config('options.holiday'))) {
+        //             $keyword = array_search($keyword, config('options.holiday'));
+        //         }
+        //         if (array_search($keyword, config('options.long_vacation'))) {
+        //             $keyword = array_search($keyword, config('options.long_vacation'));
+        //         }
+        //         $query->where(function($query) use ($keyword){
+        //             $query->where('company_name', 'LIKE', "%{$keyword}%")
+        //                 ->orWhere('company_address', 'LIKE', "%{$keyword}%")
+        //                 ->orWhere('ordering_business', 'LIKE', "%{$keyword}%")
+        //                 ->orWhere('order_details', 'LIKE', "%{$keyword}%")
+        //                 ->orWhere('scheduled_period', 'LIKE', "%{$keyword}%")
+        //                 ->orWhere('holiday', 'LIKE', "%{$keyword}%")
+        //                 ->orWhere('long_vacation', 'LIKE', "%{$keyword}%")
+        //                 ->orWhere('scheduled_period', 'LIKE', "%{$keyword}%");
+        //         });
+        //     }
+
+        //     return $query;
+        // })
+        ->orderBy('created_at', 'desc')
+        ->get();
+
+        return view('job_offers.order', [
+            'jobOffers' => $jobOffers,
+            'draftJobOffers' => $draftJobOffers,
+            'users' => $users,
+        ]);
+    }
+
 }

--- a/public/js/job_offer/create.js
+++ b/public/js/job_offer/create.js
@@ -124,26 +124,31 @@ $(document).ready(function() {
     })
  });
 
- /******************************************
- * 顧客名のdatalistで顧客名ではなく顧客IDを送信する
- ******************************************/
-  let customer_id = null;
-  // datalistのdata-id属性の値の取得
-  $('#customer_input').on('change', function () {
-    customer_id = $("#customer_list option[value='" + $(this).val() + "']").data('customer_id');
-    $('#customer_id').val(customer_id)
-  });
+    /******************************************
+     * 顧客名のdatalistで顧客名ではなく顧客IDを送信する
+     ******************************************/
+    let customer_id = null;
+    // datalistのdata-id属性の値の取得
+    $('#customer_input').on('change', function () {
+        customer_id = $("#customer_list option[value='" + $(this).val() + "']").data('customer_id');
+        $('#customer_id').val(customer_id)
+    });
 
-/******************************************
- * 下書き必須項目の表示切替
- ******************************************/
-$('.draft-require').on('change', function () {
-    if ($(this).val().length) {
-        $(this).removeClass('bg-danger text-white');
+    /******************************************
+     * 下書き必須項目の表示切替
+     ******************************************/
+     if ($('.draft-require').val().length) {
+        $('.draft-require').removeClass('bg-danger text-white');
     } else {
-        $(this).addClass('bg-danger text-white');
+        $('.draft-require').addClass('bg-danger text-white');
     }
-  });
+    $('.draft-require').on('change', function () {
+        if ($(this).val().length) {
+            $(this).removeClass('bg-danger text-white');
+        } else {
+            $(this).addClass('bg-danger text-white');
+        }
+    });
 
 
 });

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -69,6 +69,15 @@
                                         </a>
                                     </li>
                                 </div>
+                                <div>
+                                    <li>
+                                        <a href="{{ route('jobffer.order_date.index') }}" style="text-decoration: none;">
+                                            <button class="btn btn-outline-secondary btn-lg mb-2" type="button">
+                                                起算日リスト
+                                            </button>
+                                        </a>
+                                    </li>
+                                </div>
                             </div>
                         </ul>
                     </div>

--- a/resources/views/job_offers/edit.blade.php
+++ b/resources/views/job_offers/edit.blade.php
@@ -11,6 +11,7 @@
         @method('PUT')
         @csrf
         <input type="hidden" name="jobOfferId" value="{{ $jobOffer->id }}">
+        <input type="hidden" name="fromOrderDate" value="{{ $fromOrderDate }}">
         <input class="btn btn-secondary mb-2" type="button" value="印刷" onclick="window.print();" />
         @if(!$isDraftJobOffer)
         {{-- <input class="btn btn-success mb-2" type="submit" value="複製" onclick="duplicate()" /> --}}

--- a/resources/views/job_offers/order.blade.php
+++ b/resources/views/job_offers/order.blade.php
@@ -1,0 +1,106 @@
+@extends('layouts.app')
+@section('content')
+<div class="container">
+	<div class="main container-fluid">
+		<div class="row bg-light text-dark py-5">
+			<div class="col-md-8 offset-md-2">
+				<h1 class="text-center">起算日リスト</h1>
+				<div class="d-flex justify-content">
+					<form class="form-control" method="GET" action="{{ route('jobffer.order_date.index') }}">
+						<h2 class="text-center">検索</h2>
+
+						<label for="userInput">営業担当</label>
+						<select type="text" class="form-control" name="userId">
+							<option value="">営業担当を選んで下さい</option>
+							@foreach( $users as $user )
+							<option value="{{ $user->id }}" @if (Request::input('userId') == $user->id) selected @endif>{{ $user->name }}</option>
+							@endforeach
+						</select>
+
+                        <label for="jobNumberInput" class="mt-3">仕事番号</label>
+						<input class="form-control mt-1" type="search" id="jobNumberInput" placeholder="仕事番号を入力" name="jobNumber" value="{{ Request::input('jobNumber') }}">
+
+                        <label for="companyNameInput" class="mt-3">就業先名称</label>
+						<input class="form-control mt-1" type="search" id="companyNameInput" placeholder="就業先名称を入力" name="companyName" value="{{ Request::input('companyName') }}">
+
+                        <label for="orderingBusinessInput" class="mt-3">発注業務</label>
+						<input class="form-control mt-1" type="search" id="orderingBusinessInput" placeholder="就業先名称を入力" name="orderingBusiness" value="{{ Request::input('orderingBusiness') }}">
+
+                        <label for="orderDateInput" class="mt-3">起算日</label>
+						<input class="form-control mt-1" type="date" id="orderDateInput" placeholder="就業先名称を入力" name="orderDate" value="{{ Request::input('orderDate') }}">
+
+						<label class="mt-3">求人掲載サイト</label>
+                        <div class="d-flex justify-content-evenly">
+                          @foreach( config('options.posting_site') as $key => $postingSite )
+                            <div class="form-check">
+                              <input class="form-check-input" type="checkbox" name="postingSite[]" value="{{ $key }}" {{ old('postingSite') == $key ? 'checked' : '' }} id="{{ 'postingSiteInput' . $key }}" @if(is_array(Request::input('postingSite')) && in_array($key,Request::input('postingSite'))) checked @endif>
+                              <label class="form-check-label" for="{{ 'postingSiteInput' . $key }}">
+                                {{ $postingSite }}
+                              </label>
+                            </div>
+                          @endforeach
+                        </div>
+
+						{{-- <label for="keywordsInput" class="mt-3">キーワード</label>
+						<input class="form-control mt-1" type="search" id="keywordsInput" placeholder="キーワードを入力" name="keywords" value="{{ Request::input('keywords') }}"> --}}
+
+						<div class="d-grid gap-2 d-md-flex justify-content-md-end">
+							<button class="btn btn-info m-2" type="submit">検索</button>
+							<button class="btn btn-success m-2">
+									<a href="{{ route('jobffer.order_date.index') }}" class="text-white text-decoration-none">クリア</a>
+							</button>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+<div class="card-header w-75 m-auto">求人一覧</div>
+<table class="table table-bordered table-hover w-75 m-auto">
+    <thead>
+    <tr class=m-auto style="background-color: lightgray">
+        <th>求人ID</th>
+        <th>営業担当</th>
+        <th>仕事番号</th>
+        <th>就業先名称</th>
+        <th>発注業務</th>
+        <th>起算日</th>
+        <th>求人掲載サイト</th>
+        <th>操作</th>
+    </tr>
+    </thead>
+
+    @foreach($jobOffers as $jobOffer)
+        <tr>
+            <td>{{ $jobOffer->id }}</td>
+            <td>{{ $jobOffer->user->name}}</td>
+            <td>{{ $jobOffer->job_number }}</td>
+            <td>{{ $jobOffer->company_name }}</td>
+            <td>{{ $jobOffer->ordering_business }}</td>
+            <td>{{ $jobOffer->order_date }}</td>
+            <td>{{ $jobOffer->posting_site != null ? config('options.posting_site')[$jobOffer->posting_site] : '' }}</td>
+            <td>
+                <div class="d-flex justify-content-around">
+                    <a href="{{ route('job_offers.edit', ['job_offer' => $jobOffer->id]) }}">
+                        <button class="btn btn-primary" type="button">編集</button>
+                    </a>
+                </div>
+            </td>
+        </tr>
+    @endforeach
+</table>
+
+
+@endsection
+
+
+@if (session('success'))
+    <div class="alert alert-success">
+        {{ session('success') }}
+    </div>
+@endif
+
+@section('js')
+<script type="text/javascript" src="{{ asset('/js/common.js') }}"></script>
+@endsection

--- a/resources/views/job_offers/order.blade.php
+++ b/resources/views/job_offers/order.blade.php
@@ -41,9 +41,6 @@
                           @endforeach
                         </div>
 
-						{{-- <label for="keywordsInput" class="mt-3">キーワード</label>
-						<input class="form-control mt-1" type="search" id="keywordsInput" placeholder="キーワードを入力" name="keywords" value="{{ Request::input('keywords') }}"> --}}
-
 						<div class="d-grid gap-2 d-md-flex justify-content-md-end">
 							<button class="btn btn-info m-2" type="submit">検索</button>
 							<button class="btn btn-success m-2">
@@ -82,7 +79,10 @@
             <td>{{ $jobOffer->posting_site != null ? config('options.posting_site')[$jobOffer->posting_site] : '' }}</td>
             <td>
                 <div class="d-flex justify-content-around">
-                    <a href="{{ route('job_offers.edit', ['job_offer' => $jobOffer->id]) }}">
+                    <a href="{{ route('job_offers.edit', [
+                        'job_offer' => $jobOffer->id,
+                        'from_order_date' => true,
+                    ]) }}">
                         <button class="btn btn-primary" type="button">編集</button>
                     </a>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,5 +26,4 @@ Route::post('/draft/create', [App\Http\Controllers\DraftJobOfferController::clas
 Route::get('/draft/edit/{id}', [App\Http\Controllers\DraftJobOfferController::class, 'edit'])->middleware('auth')->name('draft.edit');
 Route::put('/draft/update/{id}', [App\Http\Controllers\DraftJobOfferController::class, 'update'])->name('draft.update');
 Route::delete('/draft/delete/{id}', [App\Http\Controllers\DraftJobOfferController::class, 'destroy'])->name('draft.destroy');
-
-Auth::routes();
+Route::get('/order-date', [App\Http\Controllers\JobOfferController::class, 'showOrderDate'])->name('jobffer.order_date.index');


### PR DESCRIPTION
## 概要
起算日リストデータベース情報を欲しい。
データを一覧で見たい。

6項目「担当者名、お仕事番号、就業先名称、発注業務、起算日、求人掲載サイト」を表側に出し、右側に編集ボタンを設ける。
求人一覧と同様に検索ボックスにし、上記の項目を選択肢のものは選択肢で選べるようにする。
並びは新しいものから上に並べる

ページネーションせずに、全件表示する。

## 仕様
起算日リスト画面から編集画面へ遷移して登録ボタンを押下すると、求人情報一覧画面ではなく起算日リスト画面へ遷移するようにする

## 対応Issue
Close #7 