### PR TITLE
CSV選択ボタンのバリデーションと送信ボタンの有効/無効の制御

### DIFF
--- a/public/js/customer/create.js
+++ b/public/js/customer/create.js
@@ -1,0 +1,26 @@
+$(document).ready(function() {
+	/******************************************
+	* CSVファイルの選択ボタン
+	******************************************/
+	if ($("#csv_import").val().length) {
+		// ページ読み込み時にファイルが選択されていた場合
+		$("#csv_submit").attr("disabled",false);
+	} else {
+		$("#csv_submit").attr("disabled",true);
+	}
+	$("#csv_import").change(function(){
+		// ファイルが選択されたら
+		let uploadedFile=$(this).prop('files')[0];
+		let fileType=uploadedFile.type.split("/")[1];
+		if (fileType != "csv") {
+			// 拡張子のバリデーションにひっかかった場合の処理
+			alert('CSVファイルを選択してください');
+			$("#csv_submit").attr("disabled",true);
+			$(this).val("") // input要素を空にする
+		} else {
+			// 拡張子のバリデーションをパスした場合の処理
+			$("#csv_submit").attr("disabled",false);
+		}
+   });
+
+});

--- a/public/js/job_offer/create.js
+++ b/public/js/job_offer/create.js
@@ -150,5 +150,29 @@ $(document).ready(function() {
         }
     });
 
+	/******************************************
+     * CSVファイルの選択ボタン
+     ******************************************/
+	 if ($("#csv_import").val().length) {
+		// ページ読み込み時にファイルが選択されていた場合
+		$("#csv_submit").attr("disabled",false);
+	} else {
+		$("#csv_submit").attr("disabled",true);
+	}
+	$("#csv_import").change(function(){
+		// ファイルが選択されたら
+		let uploadedFile=$(this).prop('files')[0];
+		let fileType=uploadedFile.type.split("/")[1];
+		if (fileType != "csv") {
+			// 拡張子のバリデーションにひっかかった場合の処理
+			alert('CSVファイルを選択してください');
+			$("#csv_submit").attr("disabled",true);
+			$(this).val("") // input要素を空にする
+		} else {
+			// 拡張子のバリデーションをパスした場合の処理
+			$("#csv_submit").attr("disabled",false);
+		}
+   });
+
 
 });

--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -7,7 +7,7 @@
             <div class="mb-2">
                 <label for="csv_import">CSVインポート</label><br>
                 <input type="file" id="csv_import" name="csv_import">
-                <button type="submit" class="btn btn-primary">選択したCSVを反映する</button>
+                <button id="csv_submit" type="submit" class="btn btn-primary">選択したCSVを反映する</button>
             </div>
         </form>
         <div class="card mb-4">
@@ -106,4 +106,8 @@
     </div>
 </div>
 
+@endsection
+
+@section('js')
+    <script type="text/javascript" src="{{ asset('/js/customer/create.js') }}"></script>
 @endsection

--- a/resources/views/job_offers/create.blade.php
+++ b/resources/views/job_offers/create.blade.php
@@ -7,7 +7,7 @@
             <div class="mb-2">
                 <label for="csv_import">CSVインポート</label><br>
                 <input type="file" id="csv_import" name="csv_import">
-                <button type="submit" class="btn btn-primary">選択したCSVを反映する</button>
+                <button id="csv_submit" type="submit" class="btn btn-primary" disabled>選択したCSVを反映する</button>
             </div>
         </form>
         <div class="card mb-4">


### PR DESCRIPTION
@sugaigit 
## 変更点
- 拡張子が「csv」のファイルしか選択できないように変更
- ファイルが選択されていない状態ではsubmitボタンが押下できないように変更