### PR TITLE
求人ランクの必須項目なくす、各項目の表示変更

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -280,16 +280,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.6.3",
+            "version": "3.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "9a747d29e7e6b39509b8f1847e37a23a0163ea6a"
+                "reference": "19f0dec95edd6a3c3c5ff1d188ea94c6b7fc903f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9a747d29e7e6b39509b8f1847e37a23a0163ea6a",
-                "reference": "9a747d29e7e6b39509b8f1847e37a23a0163ea6a",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/19f0dec95edd6a3c3c5ff1d188ea94c6b7fc903f",
+                "reference": "19f0dec95edd6a3c3c5ff1d188ea94c6b7fc903f",
                 "shasum": ""
             },
             "require": {
@@ -372,7 +372,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.6.3"
+                "source": "https://github.com/doctrine/dbal/tree/3.6.4"
             },
             "funding": [
                 {
@@ -388,7 +388,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-01T05:46:46+00:00"
+            "time": "2023-06-15T07:40:12+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -8349,5 +8349,5 @@
         "php": "^7.3|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/database/migrations/2022_11_18_150000_create_job_offers_table.php
+++ b/database/migrations/2022_11_18_150000_create_job_offers_table.php
@@ -53,8 +53,8 @@ class CreateJobOffersTable extends Migration
             $table->string('social_insurance', 100)->comment('社会保険加入');//
             $table->string('payment_unit_price_1', 100)->comment('支払単価①');//
             $table->string('payment_unit_1', 100)->comment('支払単位①');//
-            $table->string('carfare_1', 100)->comment('交通費①');->nullable();//
-            $table->string('carfare_payment_1', 100)->comment('交通費支払単位①');->nullable();//
+            $table->string('carfare_1', 100)->comment('交通費①')->nullable();//
+            $table->string('carfare_payment_1', 100)->comment('交通費支払単位①')->nullable();//
             $table->string('carfare_payment_remarks_1', 100)->comment('支払情報①備考')->nullable();//
             $table->string('employment_insurance_2', 100)->comment('雇用保険加入②');//
             $table->string('social_insurance_2', 100)->comment('社会保険加入②');//
@@ -74,7 +74,7 @@ class CreateJobOffersTable extends Migration
             $table->date('expected_end_date')->comment('終了予定日')->nullable();//
             $table->text('period_remarks')->comment('期間備考')->nullable();//
             $table->string('holiday')->comment('休日');//
-            $table->string('long_vacation')->comment('長期休暇');//
+            $table->string('long_vacation')->comment('長期休暇')->nullable();//
             $table->text('holiday_remarks')->comment('休日備考')->nullable();//
             $table->string('working_hours_1')->comment('勤務時間①');//
             $table->string('actual_working_hours_1')->comment('実働時間①');//

--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -76,8 +76,8 @@
                         </select>
                     </li>
                     <li class="list-group-item list-group-item-action">
-                        会社規模<span class="text-danger">*</span>
-                        <select type="text" class="form-control" name="company_size" required>
+                        会社規模
+                        <select type="text" class="form-control" name="company_size">
                             <option value="">会社規模を選んで下さい</option>
                             @foreach( config('options.company_size') as $key => $val )
                                 <option value="{{ $key }}" {{ old('company_size') == $key ? 'selected' : '' }}>{{ $val }}</option>
@@ -85,8 +85,8 @@
                         </select>
                     </li>
                     <li class="list-group-item list-group-item-action">
-                        事業展開地域<span class="text-danger">*</span>
-                        <select type="text" class="form-control" name="business_development_area" required>
+                        事業展開地域
+                        <select type="text" class="form-control" name="business_development_area" >
                             <option value="">事業展開地域を選んで下さい</option>
                             @foreach( config('options.business_development_area') as $key => $val )
                                 <option value="{{ $key }}" {{ old('business_development_area') == $key ? 'selected' : '' }}>{{ $val }}</option>
@@ -94,8 +94,8 @@
                         </select>
                     </li>
                     <li class="list-group-item list-group-item-action">
-                        取引拡大可能性<span class="text-danger">*</span>
-                        <select type="text" class="form-control" name="business_expansion_potential" required>
+                        取引拡大可能性
+                        <select type="text" class="form-control" name="business_expansion_potential">
                             <option value="">取引拡大可能性を選んで下さい</option>
                             @foreach( config('options.business_expansion_potential') as $key => $val )
                                 <option value="{{ $key }}" {{ old('business_expansion_potential') == $key ? 'selected' : '' }}>{{ $val }}</option>
@@ -103,8 +103,8 @@
                         </select>
                     </li>
                     <li class="list-group-item list-group-item-action">
-                        社歴<span class="text-danger">*</span>
-                        <select type="text" class="form-control" name="company_history" required>
+                        社歴
+                        <select type="text" class="form-control" name="company_history">
                             <option value="">社歴を選んで下さい</option>
                             @foreach( config('options.company_history') as $key => $val )
                                 <option value="{{ $key }}" {{ old('company_history') == $key ? 'selected' : '' }}>{{ $val }}</option>
@@ -112,8 +112,8 @@
                         </select>
                     </li>
                     <li class="list-group-item list-group-item-action">
-                        信頼性<span class="text-danger">*</span>
-                        <select type="text" class="form-control" name="reliability" required>
+                        信頼性
+                        <select type="text" class="form-control" name="reliability">
                             <option value="">信頼性を選んで下さい</option>
                             @foreach( config('options.reliability') as $key => $val )
                                 <option value="{{ $key }}" {{ old('reliability') == $key ? 'selected' : '' }}>{{ $val }}</option>

--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -81,9 +81,9 @@
                             </td>
                         </tr>
                         <tr>
-                            <th>会社規模<span class="text-danger">*</span></th>
+                            <th>会社規模</th>
                             <td>
-                                <select type="text" class="form-control required" name="company_size" required>
+                                <select type="text" class="form-control " name="company_size" >
                                     <option value="">会社規模を選んで下さい</option>
                                     @foreach( config('options.company_size') as $key => $company_size )
                                     <option value="{{ $key }}" {{ $key == $customer->company_size ? 'selected' : '' }}>{{ $company_size }}</option>
@@ -92,9 +92,9 @@
                             </td>
                         </tr>
                         <tr>
-                            <th>事業展開地域<span class="text-danger">*</span></th>
+                            <th>事業展開地域</th>
                             <td>
-                                <select type="text" class="form-control required" name="business_development_area" required>
+                                <select type="text" class="form-control " name="business_development_area" >
                                     <option value="">事業展開地域を選んで下さい</option>
                                     @foreach( config('options.business_development_area') as $key => $business_development_area )
                                     <option value="{{ $key }}" {{ $key == $customer->business_development_area ? 'selected' : '' }}>{{ $business_development_area }}</option>
@@ -103,9 +103,9 @@
                             </td>
                         </tr>
                         <tr>
-                            <th>取引拡大可能性<span class="text-danger">*</span></th>
+                            <th>取引拡大可能性</th>
                             <td>
-                                <select type="text" class="form-control required" name="business_expansion_potential" required>
+                                <select type="text" class="form-control" name="business_expansion_potential" >
                                     <option value="">取引拡大可能性を選んで下さい</option>
                                     @foreach( config('options.business_expansion_potential') as $key => $business_expansion_potential )
                                     <option value="{{ $key }}" {{ $key == $customer->business_expansion_potential ? 'selected' : '' }}>{{ $business_expansion_potential }}</option>
@@ -114,9 +114,9 @@
                             </td>
                         </tr>
                         <tr>
-                            <th>社歴<span class="text-danger">*</span></th>
+                            <th>社歴</th>
                             <td>
-                                <select type="text" class="form-control required" name="company_history" required>
+                                <select type="text" class="form-control" name="company_history" >
                                     <option value="">社歴を選んで下さい</option>
                                     @foreach( config('options.company_history') as $key => $company_history )
                                     <option value="{{ $key }}" {{ $key == $customer->company_history ? 'selected' : '' }}>{{ $company_history }}</option>
@@ -125,9 +125,9 @@
                             </td>
                         </tr>
                         <tr>
-                            <th>信頼性<span class="text-danger">*</span></th>
+                            <th>信頼性</th>
                             <td>
-                                <select type="text" class="form-control required" name="reliability" required>
+                                <select type="text" class="form-control" name="reliability" >
                                     <option value="">信頼性を選んで下さい</option>
                                     @foreach( config('options.reliability') as $key => $reliability )
                                     <option value="{{ $key }}" {{ $key == $customer->reliability ? 'selected' : '' }}>{{ $reliability }}</option>

--- a/resources/views/customers/index.blade.php
+++ b/resources/views/customers/index.blade.php
@@ -59,6 +59,9 @@
             <th class="text-center">顧客ID</th>
             <th class="text-center">取扱会社種別</th>
             <th class="text-center">取扱事業所</th>
+            <th class="text-center">企業ランク</th>
+            <th class="text-center">法人形態</th>
+            <th class="text-center">顧客名</th>
             <th class="text-center">業種</th>
             <th class="text-center">住所</th>
             <th class="text-center">作成者</th>
@@ -70,6 +73,9 @@
         <td>{{ $customer->id }}</td>
         <td>{{ !empty($customer->handling_type) ? config('options')['handling_type'][$customer->handling_type] :'' }}</td>
         <td>{{ !empty($customer->handling_office) ? config('options')['handling_office'][$customer->handling_office] :'' }}</td>
+        <td>{{ $customer->rank }}</td>
+        <td>{{ !empty($customer->corporate_type) ? config('options')['corporate_type'][$customer->corporate_type] :'' }}</td>
+        <td>{{ $customer->customer_name }}</td>
         <td>{{ !empty($customer->industry) ? config('options')['industry'][$customer->industry] :'' }}</td>
         <td>{{ $customer->address }}</td>
         <td>{{ $customer->user->name }}</td>

--- a/resources/views/job_offers/create.blade.php
+++ b/resources/views/job_offers/create.blade.php
@@ -134,9 +134,9 @@
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th>発注拠点数<span class="text-danger">*</span></th>
+                                    <th>発注拠点数</th>
                                     <td>
-                                        <select type="text" class="form-control required" name="number_of_ordering_bases" required>
+                                        <select type="text" class="form-control" name="number_of_ordering_bases">
                                             <option value="">発注拠点数を選んで下さい</option>
                                             @foreach( config('options.number_of_ordering_bases') as $key => $number_of_ordering_bases )
                                                 <option value="{{ $key }}" {{ old('number_of_ordering_bases') == $key ? 'selected' : '' }}>{{ $number_of_ordering_bases }}</option>
@@ -145,9 +145,9 @@
                                     </td>
                                 </tr>
 								<tr>
-									<th>発注人数<span class="text-danger">*</span></th>
+									<th>発注人数</th>
 									<td>
-										<select type="text" class="form-control required" name="order_number" required>
+										<select type="text" class="form-control" name="order_number" >
 											<option value="">発注人数を選んで下さい</option>
 											@foreach( config('options.order_number') as $key => $order_number )
 												<option value="{{ $key }}" {{ old('order_number') == $key ? 'selected' : '' }}>{{ $order_number }}</option>
@@ -156,9 +156,9 @@
 									</td>
 								</tr>
 								<tr>
-									<th>取引継続期間<span class="text-danger">*</span></th>
+									<th>取引継続期間</th>
 									<td>
-										<select type="text" class="form-control required" name="transaction_duration" required>
+										<select type="text" class="form-control" name="transaction_duration" >
 											<option value="">取引継続期間を選んで下さい</option>
 											@foreach( config('options.transaction_duration') as $key => $transaction_duration )
 												<option value="{{ $key }}" {{ old('transaction_duration') == $key ? 'selected' : '' }}>{{ $transaction_duration }}</option>
@@ -167,9 +167,9 @@
 									</td>
 								</tr>
 								<tr>
-									<th>売上見込額<span class="text-danger">*</span></th>
+									<th>売上見込額</th>
 									<td>
-										<select type="text" class="form-control required" name="expected_sales" required>
+										<select type="text" class="form-control" name="expected_sales" >
 											<option value="">売上見込額を選んで下さい</option>
 											@foreach( config('options.expected_sales') as $key => $expected_sales )
 												<option value="{{ $key }}" {{ old('expected_sales') == $key ? 'selected' : '' }}>{{ $expected_sales }}</option>
@@ -178,9 +178,9 @@
 									</td>
 								</tr>
 								<tr>
-									<th>利益率<span class="text-danger">*</span></th>
+									<th>利益率</th>
 									<td>
-										<select type="text" class="form-control required" name="profit_rate" required>
+										<select type="text" class="form-control " name="profit_rate">
 											<option value="">利益率を選んで下さい</option>
 											@foreach( config('options.profit_rate') as $key => $profit_rate )
 												<option value="{{ $key }}" {{ old('profit_rate') == $key ? 'selected' : '' }}>{{ $profit_rate }}</option>
@@ -189,9 +189,9 @@
 									</td>
 								</tr>
 								<tr>
-									<th>特別事項<span class="text-danger">*</span></th>
+									<th>特別事項</th>
 									<td>
-										<select type="text" class="form-control required" name="special_matters" required>
+										<select type="text" class="form-control" name="special_matters">
 											<option value="">特別事項を選んで下さい</option>
 											@foreach( config('options.special_matters') as $key => $special_matters )
 												<option value="{{ $key }}" {{ old('special_matters') == $key ? 'selected' : '' }}>{{ $special_matters }}</option>

--- a/resources/views/job_offers/create.blade.php
+++ b/resources/views/job_offers/create.blade.php
@@ -130,7 +130,7 @@
                                 <tr>
                                     <th>発注業務詳細<span class="text-danger">*</span></th>
                                     <td>
-                                        <textarea rows="3" type="text" class="form-control required" name="order_details" required>{{ old('order_details')}}</textarea>
+                                        <textarea rows="5" type="text" class="form-control required" name="order_details" required>{{ old('order_details')}}</textarea>
                                     </td>
                                 </tr>
                                 <tr>
@@ -550,7 +550,7 @@
                                 <tr>
                                     <th>休日備考</th>
                                     <td>
-                                        <textarea rows="3" class="form-control" name="holiday_remarks">{{ old('holiday_remarks') }}</textarea>
+                                        <textarea rows="1" class="form-control" name="holiday_remarks">{{ old('holiday_remarks') }}</textarea>
                                     </td>
                                 </tr>
                                 <tr>
@@ -626,7 +626,7 @@
                                 <tr>
                                     <th>勤務時間備考</th>
                                     <td>
-                                        <textarea rows="3" type="text" class="form-control" name="working_hours_remarks">{{ old('working_hours_remarks') }}</textarea>
+                                        <textarea rows="5" type="text" class="form-control" name="working_hours_remarks">{{ old('working_hours_remarks') }}</textarea>
                                     </td>
                                 </tr>
                                 <tr>
@@ -667,7 +667,7 @@
                                 <tr>
                                     <th>交通通勤備考</th>
                                     <td>
-                                        <textarea rows="3" class="form-control" name="traffic_commuting_remarks" >{{ old('traffic_commuting_remarks') }}</textarea>
+                                        <textarea rows="5" class="form-control" name="traffic_commuting_remarks" >{{ old('traffic_commuting_remarks') }}</textarea>
                                     </td>
                                 </tr>
                                 <tr>
@@ -770,7 +770,7 @@
                                 <tr>
                                     <th>職場の雰囲気・備考</th>
                                     <td>
-                                        <textarea type="textarea" rows="3" class="form-control" name="remarks_workplace">{{ old('remarks_workplace') }}</textarea>
+                                        <textarea type="textarea" rows="10" class="form-control" name="remarks_workplace">{{ old('remarks_workplace') }}</textarea>
                                     </td>
                                 </tr>
                                 <tr>
@@ -878,7 +878,7 @@
                                 <tr class="afterRecruit">
                                     <th>その他</th>
                                     <td>
-                                        <textarea rows="3" type="text" class="form-control" name="introduction_others">{{ old('introduction_others') }}</textarea>
+                                        <textarea rows="5" type="text" class="form-control" name="introduction_others">{{ old('introduction_others') }}</textarea>
                                     </td>
                                 </tr>
                             </tbody>

--- a/resources/views/job_offers/detail.blade.php
+++ b/resources/views/job_offers/detail.blade.php
@@ -181,13 +181,13 @@
                         <th>発注業務詳細<span class="text-danger">*</span></th>
                         <td>
                             @if (is_null(old('order_details')))
-                            <input  style="pointer-events: none;" tabindex="-1" type="text" maxlength="100" class="form-control required" name="order_details" value="{{ isset($jobOffer->order_details) ? $jobOffer->order_details : '' }}" required>
+                            <textarea style="pointer-events: none;" type="textarea" rows="5" class="form-control" name="order_details" required>{{ isset( $jobOffer->order_details) ? $jobOffer->order_details : '' }}</textarea>
                             @else
-                            <input  style="pointer-events: none;" tabindex="-1" type="text" maxlength="100" class="form-control required" name="order_details" value="{{ old('order_details') }}" required>
+                            <textarea style="pointer-events: none;" type="textarea" rows="5" class="form-control" name="order_details" required> {{ old('order_details') }}</textarea>
                             @endif
                         </td>
                     </tr>
-                    <th>発注拠点数<span class="text-danger">*</span></th>
+                    <th>発注拠点数</th>
                     <td>
                         <select  style="pointer-events: none;" tabindex="-1" type="text" class="form-control required" name="number_of_ordering_bases" required>
                             <option value="">発注拠点数を選んで下さい</option>
@@ -202,7 +202,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>発注人数<span class="text-danger">*</span></th>
+                    <th>発注人数</th>
                     <td>
                         <select  style="pointer-events: none;" tabindex="-1" type="text" class="form-control required" name="order_number" required>
                             <option value="">発注人数を選んで下さい</option>
@@ -217,7 +217,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>取引継続期間<span class="text-danger">*</span></th>
+                    <th>取引継続期間</th>
                     <td>
                         <select  style="pointer-events: none;" tabindex="-1" type="text" class="form-control required" name="transaction_duration" required>
                             <option value="">取引継続期間を選んで下さい</option>
@@ -232,7 +232,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>売上見込額<span class="text-danger">*</span></th>
+                    <th>売上見込額</th>
                     <td>
                         <select  style="pointer-events: none;" tabindex="-1" type="text" class="form-control required" name="expected_sales" required>
                             <option value="">売上見込額を選んで下さい</option>
@@ -247,7 +247,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>利益率<span class="text-danger">*</span></th>
+                    <th>利益率</th>
                     <td>
                         <select  style="pointer-events: none;" tabindex="-1" type="text" class="form-control required" name="profit_rate" required>
                             <option value="">利益率を選んで下さい</option>
@@ -262,7 +262,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>特別事項<span class="text-danger">*</span></th>
+                    <th>特別事項</th>
                     <td>
                         <select  style="pointer-events: none;" tabindex="-1" type="text" class="form-control required" name="special_matters" required>
                             <option value="">特別事項を選んで下さい</option>
@@ -771,9 +771,9 @@
                         <th>休日備考</th>
                         <td>
                             @if (is_null(old('holiday_remarks')))
-                            <textarea type="textarea" rows="3" class="form-control" name="holiday_remarks"> {{ isset($jobOffer->holiday_remarks) ? $jobOffer->holiday_remarks : '' }}</textarea>
+                            <textarea style="pointer-events: none;" tabindex="-1" type="textarea" rows="1" class="form-control" name="holiday_remarks"> {{ isset($jobOffer->holiday_remarks) ? $jobOffer->holiday_remarks : '' }}</textarea>
                             @else
-                            <textarea type="textarea" rows="3" class="form-control" name="holiday_remarks"> {{ old('holiday_remarks') }}</textarea>
+                            <textarea type="textarea" rows="1" class="form-control" name="holiday_remarks"> {{ old('holiday_remarks') }}</textarea>
                             @endif
                         </td>
                     </tr>
@@ -891,9 +891,9 @@
                         <th>勤務時間備考</th>
                         <td>
                             @if (is_null(old('working_hours_remarks')))
-                            <textarea type="textarea" rows="3" class="form-control" name="working_hours_remarks"> {{ isset($jobOffer->working_hours_remarks) ? $jobOffer->working_hours_remarks : '' }}</textarea>
+                            <textarea style="pointer-events: none;"  rows="1" class="form-control" name="working_hours_remarks"> {{ isset($jobOffer->working_hours_remarks) ? $jobOffer->working_hours_remarks : '' }}</textarea>
                             @else
-                            <textarea type="textarea" rows="3" class="form-control" name="working_hours_remarks"> {{ old('working_hours_remarks') }}</textarea>
+                            <textarea type="textarea" rows="1" class="form-control" name="working_hours_remarks"> {{ old('working_hours_remarks') }}</textarea>
                             @endif
                         </td>
                     </tr>
@@ -1111,9 +1111,9 @@
                         <th>職場の雰囲気・備考</th>
                         <td>
                             @if (is_null(old('remarks_workplace')))
-                            <textarea type="textarea" rows="3" class="form-control" name="remarks_workplace">{{ isset( $jobOffer->remarks_workplace) ? $jobOffer->remarks_workplace : '' }}</textarea>
+                            <textarea style="pointer-events: none;" type="textarea" rows="10" class="form-control" name="remarks_workplace">{{ isset( $jobOffer->remarks_workplace) ? $jobOffer->remarks_workplace : '' }}</textarea>
                             @else
-                            <textarea type="textarea" rows="3" class="form-control" name="remarks_workplace">{{ old('remarks_workplace') }}</textarea>
+                            <textarea style="pointer-events: none;" type="textarea" rows="10" class="form-control" name="remarks_workplace">{{ old('remarks_workplace') }}</textarea>
                             @endif
                         </td>
                     </tr>

--- a/resources/views/job_offers/edit.blade.php
+++ b/resources/views/job_offers/edit.blade.php
@@ -179,9 +179,9 @@
                         <th>発注業務詳細<span class="text-danger">*</span></th>
                         <td>
                             @if (is_null(old('order_details')))
-                            <textarea type="text" maxlength="100" class="form-control required" name="order_details" required> {{ isset($jobOffer->order_details) ? $jobOffer->order_details : '' }} </textarea>
+                            <textarea type="text" maxlength="100" rows="5" class="form-control required" name="order_details" required> {{ isset($jobOffer->order_details) ? $jobOffer->order_details : '' }} </textarea>
                             @else
-                            <textarea type="textarea" rows="3" class="form-control" name="order_details" required> {{ old('order_details') }}</textarea>
+                            <textarea type="textarea" rows="5" class="form-control" name="order_details" required> {{ old('order_details') }}</textarea>
                             @endif
                         </td>
                     </tr>
@@ -523,9 +523,9 @@
                         </td>
                     </tr>
                     <tr class="payment-2">
-                        <th>雇用保険加入②<span class="text-danger">*</span></th>
+                        <th>雇用保険加入②</th>
                         <td>
-                            <select type="text" class="form-control required" name="employment_insurance_2" required>
+                            <select type="text" class="form-control required" name="employment_insurance_2">
                             <option value="">雇用保険の有無を選んで下さい</option>
                             @foreach( config('options.existence') as $key => $employment_insurance_2 )
                                 @if (is_null(old('employment_insurance_2')))
@@ -538,9 +538,9 @@
                         </td>
                     </tr>
                     <tr class="payment-2">
-                        <th>社会保険加入②<span class="text-danger">*</span></th>
+                        <th>社会保険加入②</th>
                         <td>
-                            <select type="text" class="form-control required" name="social_insurance_2" required>
+                            <select type="text" class="form-control required" name="social_insurance_2">
                             <option value="">社会保険の有無を選んで下さい</option>
                             @foreach( config('options.existence') as $key => $social_insurance_2 )
                                 @if (is_null(old('social_insurance_2')))
@@ -612,9 +612,9 @@
                         </td>
                     </tr>
                     <tr class="payment-3">
-                        <th>雇用保険加入③<span class="text-danger">*</span></th>
+                        <th>雇用保険加入③</th>
                         <td>
-                            <select type="text" class="form-control required" name="employment_insurance_3" required>
+                            <select type="text" class="form-control required" name="employment_insurance_3" >
                             <option value="">雇用保険の有無を選んで下さい</option>
                             @foreach( config('options.existence') as $key => $employment_insurance_3 )
                                 @if (is_null(old('employment_insurance_3')))
@@ -627,9 +627,9 @@
                         </td>
                     </tr>
                     <tr class="payment-3">
-                        <th>社会保険加入③<span class="text-danger">*</span></th>
+                        <th>社会保険加入③</th>
                         <td>
-                            <select type="text" class="form-control required" name="social_insurance_3" required>
+                            <select type="text" class="form-control required" name="social_insurance_3">
                             <option value="">社会保険の有無を選んで下さい</option>
                             @foreach( config('options.existence') as $key => $social_insurance_3 )
                                 @if (is_null(old('social_insurance_3')))
@@ -770,9 +770,9 @@
                         <th>休日備考</th>
                         <td>
                             @if (is_null(old('holiday_remarks')))
-                            <textarea type="textarea" rows="3" class="form-control" name="holiday_remarks"> {{ isset($jobOffer->holiday_remarks) ? $jobOffer->holiday_remarks : '' }}</textarea>
+                            <textarea type="textarea" rows="1" class="form-control" name="holiday_remarks"> {{ isset($jobOffer->holiday_remarks) ? $jobOffer->holiday_remarks : '' }}</textarea>
                             @else
-                            <textarea type="textarea" rows="3" class="form-control" name="holiday_remarks"> {{ old('holiday_remarks') }}</textarea>
+                            <textarea type="textarea" rows="1" class="form-control" name="holiday_remarks"> {{ old('holiday_remarks') }}</textarea>
                             @endif
                         </td>
                     </tr>
@@ -890,9 +890,9 @@
                         <th>勤務時間備考</th>
                         <td>
                             @if (is_null(old('working_hours_remarks')))
-                            <textarea type="textarea" rows="3" class="form-control" name="working_hours_remarks"> {{ isset($jobOffer->working_hours_remarks) ? $jobOffer->working_hours_remarks : '' }}</textarea>
+                            <textarea type="textarea" rows="1" class="form-control" name="working_hours_remarks"> {{ isset($jobOffer->working_hours_remarks) ? $jobOffer->working_hours_remarks : '' }}</textarea>
                             @else
-                            <textarea type="textarea" rows="3" class="form-control" name="working_hours_remarks"> {{ old('working_hours_remarks') }}</textarea>
+                            <textarea type="textarea" rows="1" class="form-control" name="working_hours_remarks"> {{ old('working_hours_remarks') }}</textarea>
                             @endif
                         </td>
                     </tr>
@@ -1110,9 +1110,9 @@
                         <th>職場の雰囲気・備考</th>
                         <td>
                             @if (is_null(old('remarks_workplace')))
-                            <textarea type="textarea" rows="3" class="form-control" name="remarks_workplace">{{ isset( $jobOffer->remarks_workplace) ? $jobOffer->remarks_workplace : '' }}</textarea>
+                            <textarea type="textarea" rows="10" class="form-control" name="remarks_workplace">{{ isset( $jobOffer->remarks_workplace) ? $jobOffer->remarks_workplace : '' }}</textarea>
                             @else
-                            <textarea type="textarea" rows="3" class="form-control" name="remarks_workplace">{{ old('remarks_workplace') }}</textarea>
+                            <textarea type="textarea" rows="10" class="form-control" name="remarks_workplace">{{ old('remarks_workplace') }}</textarea>
                             @endif
                         </td>
                     </tr>

--- a/resources/views/job_offers/edit.blade.php
+++ b/resources/views/job_offers/edit.blade.php
@@ -11,7 +11,11 @@
         @method('PUT')
         @csrf
         <input type="hidden" name="jobOfferId" value="{{ $jobOffer->id }}">
-        @if($isDraftJobOffer)
+        <input class="btn btn-secondary mb-2" type="button" value="印刷" onclick="window.print();" />
+        @if(!$isDraftJobOffer)
+        {{-- <input class="btn btn-success mb-2" type="submit" value="複製" onclick="duplicate()" /> --}}
+        <input class="btn btn-success mb-2" type="submit" name="duplicate" value="複製">
+        @else
         <input type="hidden" name="draftJobOfferId" value="{{ $jobOffer->id }}">
         @endif
         <div class="card mb-4">
@@ -92,7 +96,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <th>顧客<span class="text-danger">*</span></th>
+                        <th>顧客名<span class="text-danger">*</span></th>
                         <td>
                             <select type="text" class="form-control required" name="customer_id" required>
                             <option value="">顧客を選んで下さい</option>
@@ -175,99 +179,99 @@
                         <th>発注業務詳細<span class="text-danger">*</span></th>
                         <td>
                             @if (is_null(old('order_details')))
-                            <input type="text" maxlength="100" class="form-control required" name="order_details" value="{{ isset($jobOffer->order_details) ? $jobOffer->order_details : '' }}" required>
+                            <textarea type="text" maxlength="100" class="form-control required" name="order_details" required> {{ isset($jobOffer->order_details) ? $jobOffer->order_details : '' }} </textarea>
                             @else
-                            <input type="text" maxlength="100" class="form-control required" name="order_details" value="{{ old('order_details') }}" required>
+                            <textarea type="textarea" rows="3" class="form-control" name="order_details" required> {{ old('order_details') }}</textarea>
                             @endif
                         </td>
                     </tr>
                     <tr>
-                        <th>発注拠点数<span class="text-danger">*</span></th>
+                        <th>発注拠点数</th>
                         <td>
-                            <select type="text" class="form-control required" name="number_of_ordering_bases" required>
+                            <select type="text" class="form-control" name="number_of_ordering_bases">
                                 <option value="">発注拠点数を選んで下さい</option>
                                 @foreach( config('options.number_of_ordering_bases') as $key => $number_of_ordering_bases )
-                                    @if (is_null(old('number_of_ordering_bases')))
-                                        <option value="{{ $key }}" {{ $key == $jobOffer->number_of_ordering_bases ? 'selected' : '' }}>{{ $number_of_ordering_bases }}</option>
-                                    @else
-                                        <option value="{{ $key }}" {{ old('number_of_ordering_bases') == $key ? 'selected' : '' }}>{{ $number_of_ordering_bases }}</option>
-                                    @endif
-                                @endforeach
+                                @if (is_null(old('number_of_ordering_bases')))
+                                <option value="{{ $key }}" {{ $key == $jobOffer->number_of_ordering_bases ? 'selected' : '' }}>{{ $number_of_ordering_bases }}</option>
+                                @else
+                                <option value="{{ $key }}" {{ $key == old('number_of_ordering_bases') ? 'selected' : '' }}>{{ $number_of_ordering_bases }}</option>
+                                @endif
+                                    @endforeach
                             </select>
                         </td>
                     </tr>
                     <tr>
-                        <th>発注人数<span class="text-danger">*</span></th>
+                        <th>発注人数</th>
                         <td>
-                            <select type="text" class="form-control required" name="order_number" required>
+                            <select type="text" class="form-control" name="order_number" >
                                 <option value="">発注人数を選んで下さい</option>
                                 @foreach( config('options.order_number') as $key => $order_number )
-                                    @if (is_null(old('order_number')))
-                                        <option value="{{ $key }}" {{ $key == $jobOffer->order_number ? 'selected' : '' }}>{{ $order_number }}</option>
+                                @if (is_null(old('order_number')))
+                                    <option value="{{ $key }}" {{ $key == $jobOffer->order_number ? 'selected' : '' }}>{{ $order_number }}</option>
                                     @else
-                                        <option value="{{ $key }}" {{ old('order_number') == $key ? 'selected' : '' }}>{{ $order_number }}</option>
+                                    <option value="{{ $key }}" {{ $key == old('order_number') ? 'selected' : '' }}>{{ $order_number }}</option>
                                     @endif
                                 @endforeach
                             </select>
                         </td>
                     </tr>
                     <tr>
-                        <th>取引継続期間<span class="text-danger">*</span></th>
+                        <th>取引継続期間</th>
                         <td>
-                            <select type="text" class="form-control required" name="transaction_duration" required>
+                            <select type="text" class="form-control" name="transaction_duration" >
                                 <option value="">取引継続期間を選んで下さい</option>
                                 @foreach( config('options.transaction_duration') as $key => $transaction_duration )
-                                    @if (is_null(old('transaction_duration')))
-                                        <option value="{{ $key }}" {{ $key == $jobOffer->transaction_duration ? 'selected' : '' }}>{{ $transaction_duration }}</option>
+                                @if (is_null(old('transaction_duration')))
+                                    <option value="{{ $key }}" {{ $key == $jobOffer->transaction_duration ? 'selected' : '' }}>{{ $transaction_duration }}</option>
                                     @else
-                                        <option value="{{ $key }}" {{ old('transaction_duration') == $key ? 'selected' : '' }}>{{ $transaction_duration }}</option>
+                                    <option value="{{ $key }}" {{ $key == old('transaction_duration') ? 'selected' : '' }}>{{ $transaction_duration }}</option>
                                     @endif
                                 @endforeach
                             </select>
                         </td>
                     </tr>
                     <tr>
-                        <th>売上見込額<span class="text-danger">*</span></th>
+                        <th>売上見込額</th>
                         <td>
-                            <select type="text" class="form-control required" name="expected_sales" required>
+                            <select type="text" class="form-control" name="expected_sales" >
                                 <option value="">売上見込額を選んで下さい</option>
                                 @foreach( config('options.expected_sales') as $key => $expected_sales )
-                                    @if (is_null(old('expected_sales')))
-                                        <option value="{{ $key }}" {{ $key == $jobOffer->expected_sales ? 'selected' : '' }}>{{ $expected_sales }}</option>
+                                @if (is_null(old('expected_sales')))
+                                    <option value="{{ $key }}" {{ $key == $jobOffer->expected_sales ? 'selected' : '' }}>{{ $expected_sales }}</option>
                                     @else
-                                        <option value="{{ $key }}" {{ old('expected_sales') == $key ? 'selected' : '' }}>{{ $expected_sales }}</option>
+                                    <option value="{{ $key }}" {{ $key == old('expected_sales') ? 'selected' : '' }}>{{ $expected_sales }}</option>
                                     @endif
                                 @endforeach
                             </select>
                         </td>
                     </tr>
                     <tr>
-                        <th>利益率<span class="text-danger">*</span></th>
+                        <th>利益率</th>
                         <td>
-                            <select type="text" class="form-control required" name="profit_rate" required>
+                            <select type="text" class="form-control " name="profit_rate">
                                 <option value="">利益率を選んで下さい</option>
                                 @foreach( config('options.profit_rate') as $key => $profit_rate )
-                                    @if (is_null(old('profit_rate')))
-                                        <option value="{{ $key }}" {{ $key == $jobOffer->profit_rate ? 'selected' : '' }}>{{ $profit_rate }}</option>
+                                @if (is_null(old('profit_rate')))
+                                    <option value="{{ $key }}" {{ $key == $jobOffer->profit_rate ? 'selected' : '' }}>{{ $profit_rate }}</option>
                                     @else
-                                        <option value="{{ $key }}" {{ old('profit_rate') == $key ? 'selected' : '' }}>{{ $profit_rate }}</option>
+                                    <option value="{{ $key }}" {{ $key == old('profit_rate') ? 'selected' : '' }}>{{ $profit_rate }}</option>
                                     @endif
                                 @endforeach
                             </select>
                         </td>
                     </tr>
                     <tr>
-                        <th>特別事項<span class="text-danger">*</span></th>
+                        <th>特別事項</th>
                         <td>
-                            <select type="text" class="form-control required" name="special_matters" required>
+                            <select type="text" class="form-control" name="special_matters">
                                 <option value="">特別事項を選んで下さい</option>
                                 @foreach( config('options.special_matters') as $key => $special_matters )
-                                    @if (is_null(old('special_matters')))
-                                        <option value="{{ $key }}" {{ $key == $jobOffer->special_matters ? 'selected' : '' }}>{{ $special_matters }}</option>
+                                @if (is_null(old('special_matters')))
+                                    <option value="{{ $key }}" {{ $key == $jobOffer->special_matters ? 'selected' : '' }}>{{ $special_matters }}</option>
                                     @else
-                                        <option value="{{ $key }}" {{ old('special_matters') == $key ? 'selected' : '' }}>{{ $special_matters }}</option>
+                                    <option value="{{ $key }}" {{ $key == old('special_matters') ? 'selected' : '' }}>{{ $special_matters }}</option>
                                     @endif
-                                @endforeach
+                                    @endforeach
                             </select>
                         </td>
                     </tr>
@@ -521,7 +525,7 @@
                     <tr class="payment-2">
                         <th>雇用保険加入②<span class="text-danger">*</span></th>
                         <td>
-                            <select type="text" class="form-control required" name="employment_insurance_2">
+                            <select type="text" class="form-control required" name="employment_insurance_2" required>
                             <option value="">雇用保険の有無を選んで下さい</option>
                             @foreach( config('options.existence') as $key => $employment_insurance_2 )
                                 @if (is_null(old('employment_insurance_2')))
@@ -536,7 +540,7 @@
                     <tr class="payment-2">
                         <th>社会保険加入②<span class="text-danger">*</span></th>
                         <td>
-                            <select type="text" class="form-control required" name="social_insurance_2">
+                            <select type="text" class="form-control required" name="social_insurance_2" required>
                             <option value="">社会保険の有無を選んで下さい</option>
                             @foreach( config('options.existence') as $key => $social_insurance_2 )
                                 @if (is_null(old('social_insurance_2')))
@@ -610,7 +614,7 @@
                     <tr class="payment-3">
                         <th>雇用保険加入③<span class="text-danger">*</span></th>
                         <td>
-                            <select type="text" class="form-control required" name="employment_insurance_3">
+                            <select type="text" class="form-control required" name="employment_insurance_3" required>
                             <option value="">雇用保険の有無を選んで下さい</option>
                             @foreach( config('options.existence') as $key => $employment_insurance_3 )
                                 @if (is_null(old('employment_insurance_3')))
@@ -625,7 +629,7 @@
                     <tr class="payment-3">
                         <th>社会保険加入③<span class="text-danger">*</span></th>
                         <td>
-                            <select type="text" class="form-control required" name="social_insurance_3">
+                            <select type="text" class="form-control required" name="social_insurance_3" required>
                             <option value="">社会保険の有無を選んで下さい</option>
                             @foreach( config('options.existence') as $key => $social_insurance_3 )
                                 @if (is_null(old('social_insurance_3')))
@@ -1342,7 +1346,6 @@
             <th>日付</th>
             <th>項目</th>
             <th>詳細</th>
-            <th>操作</th>
           </tr>
           @if(isset($activityRecords))
           @foreach($activityRecords as $activityRecord)
@@ -1350,12 +1353,6 @@
               <td>{{ $activityRecord->date }}</td>
               <td>{{ config('options.item')[$activityRecord->item] }}</td>
               <td>{{ $activityRecord->detail }}</td>
-              <td>
-                {{-- <a href="{{ route('job_offers.edit', ['job_offer' => $jobOffer->id]) }}"> --}}
-                <a href="{{ route('activity.edit', $activityRecord->id) }}">
-                    <button class="btn btn-primary mb-2 me-3" type="button">編集</button>
-                </a>
-              </td>
           </tr>
           @endforeach
           @endif


### PR DESCRIPTION
@hiraokakoichi 
ご確認お願いします。

現状エラーとなっている部分
・求人編集画面で登録ボタンが押せない
・求人新規登録の求人ランクの必須を外すとエラーが出て進めない